### PR TITLE
Fix for 16-bit mode

### DIFF
--- a/smileds.c
+++ b/smileds.c
@@ -184,7 +184,11 @@ bool leds_init(int init_led_count) {
     TXDATA_T *tx_offset=&tx_buffer[LED_TX_OSET(0)];
     for (uint32_t b=0; b<led_count*LED_NBITS; b++)
     {
+#if LED_NCHANS <= 8
         tx_offset[0]=0xff; //stays this way
+#else
+        tx_offset[0]=0xffff; //stays this way
+#endif
         tx_offset[1]=0x00; //will be changed via setPixel
         tx_offset[2]=0x00; //stays this way
         tx_offset += BIT_NPULSES;


### PR DESCRIPTION
Hey,
thanks a lot for making this project public.
Actually I'm not using your code with node.js but with Python bindings, which works quite nicely too.

However, I came across a bug in `smileds.c` in function `leds_init()`:
For 16-bit operation, `tx_offset[0]` must be initialized with `0xffff` instead of `0xff`.
Took me a while to figure this one out - the "rightmost" LED strands were behaving erratic or not doing anything at all.

Cheers!